### PR TITLE
update GitHub Actions to use latest upload and deploy pages actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
       - run: yarn install --immutable --immutable-cache --check-cache
       - run: yarn build
       - name: prepare deploy
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: build
   deploy:
@@ -40,4 +40,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for Node.js to use the latest versions of actions for uploading and deploying artifacts.

* [`.github/workflows/nodejs.yml`](diffhunk://#diff-e98936aa52a6dd7416e4296e9628456227d834f7245967383fd9ff80fd985dadL28-R28): Updated `actions/upload-pages-artifact` from version 1 to version 3.
* [`.github/workflows/nodejs.yml`](diffhunk://#diff-e98936aa52a6dd7416e4296e9628456227d834f7245967383fd9ff80fd985dadL43-R43): Updated `actions/deploy-pages` from version 1 to version 4.