### PR TITLE
Refactor GitHub repository types and update components to use typed interfaces

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   cypress:
     name: cypress
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: [22.x]

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     strategy:
       matrix:
@@ -29,7 +29,7 @@ jobs:
         with:
           path: build
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     permissions:
       pages: write

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,25 +3,20 @@ import { SearchBar } from './SearchBar'
 import { github } from '../api/github'
 import { MainContent } from './MainContent'
 import { Footer } from './Footer'
+import { GitHubRepository, ApiResponse, ApiError } from '../types/github'
 import '../css/Top.css'
 
 const maxRepoSize = 100
 
-type responseType = {
-  status: number,
-  data: any,
-}
-
-type errorType = { response: {status: number, message: string}}
 
 const App: React.FC = () => {
-  const [starredRepos, setStarredRepos] = useState<any[]>([]);
+  const [starredRepos, setStarredRepos] = useState<GitHubRepository[]>([]);
   const [name, setName] = useState('');
   const [httpStatus, setHttpStatus] = useState(200);
   const [loading, setLoading] = useState(false);
 
   const onSearchSubmit = async (searchName: string) => {
-    let response = {} as responseType;
+    let response = {} as ApiResponse<GitHubRepository[]>;
     try {
       setLoading(true);
       let currentPage = 1;
@@ -57,7 +52,8 @@ const App: React.FC = () => {
       setLoading(false);
     } catch (error) {
       setName(searchName);
-      setHttpStatus((error as errorType).response.status);
+      const apiError = error as ApiError;
+      setHttpStatus(apiError.response?.status || 500);
       setLoading(false);
     }
   };

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -4,12 +4,13 @@ import { NoStarRepo } from './NoStarRepo'
 import { NameError } from './NameError'
 import { Loading } from './Loading'
 import { NoContent } from './NoContent'
+import { GitHubRepository } from '../types/github'
 
 interface Props {
   loading: boolean
   name: string
   httpStatus: number
-  starredRepos: any
+  starredRepos: GitHubRepository[]
 }
 
 export const MainContent: React.FC<Props> = ({

--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -1,17 +1,9 @@
 import React from 'react'
+import { GitHubRepository } from '../types/github'
 import '../css/RepoCard.css'
 
 export type RepoCardType = {
-  repo: {
-    name: string
-    html_url: string
-    description: string
-    owner: {
-      login: string
-    }
-    language: string
-    stargazers_count: number
-  }
+  repo: GitHubRepository
 }
 
 export const RepoCard: React.FC<RepoCardType> = ({repo}) => {

--- a/src/components/RepoList.tsx
+++ b/src/components/RepoList.tsx
@@ -1,21 +1,9 @@
 import React from 'react'
 import { RepoCard } from './RepoCard'
+import { GitHubRepository } from '../types/github'
 
 interface Props {
-  repos: Array<RepoCard>
-}
-
-// eslint-disable-next-line
-interface RepoCard {
-  id: string
-  name: string
-  html_url: string
-  description: string
-  owner: {
-    login: string
-  }
-  language: string
-  stargazers_count: number
+  repos: GitHubRepository[]
 }
 
 export const RepoList: React.FC<Props> = ({ repos }) => (

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,36 @@
+export interface GitHubRepository {
+  id: number;
+  name: string;
+  html_url: string;
+  description: string | null;
+  owner: {
+    login: string;
+    avatar_url: string;
+  };
+  language: string | null;
+  stargazers_count: number;
+  created_at: string;
+  updated_at: string;
+  forks_count: number;
+  open_issues_count: number;
+  topics: string[];
+  archived: boolean;
+  disabled: boolean;
+  private: boolean;
+}
+
+export interface ApiResponse<T> {
+  status: number;
+  data: T;
+}
+
+export interface ApiError {
+  response?: {
+    status: number;
+    data?: {
+      message?: string;
+    };
+  };
+  request?: any;
+  message: string;
+}


### PR DESCRIPTION
This pull request introduces a refactor to improve type safety and maintainability by replacing `any` types with specific TypeScript interfaces. It also centralizes API-related types in a new `github.ts` file. The most important changes include defining new interfaces for GitHub API data structures, updating components to use these interfaces, and improving error handling.

### TypeScript Interface Definitions:
* Added a new `GitHubRepository` interface to represent repository data, along with `ApiResponse` and `ApiError` interfaces, in `src/types/github.ts`. These interfaces provide a strongly-typed structure for API responses and errors.

### Component Updates for Type Safety:
* Updated `App.tsx` to replace `any` types with `GitHubRepository` and `ApiResponse` in state variables and API response handling. Improved error handling by leveraging the `ApiError` interface. [[1]](diffhunk://#diff-86963609bec6fda3d34233676d5ae33f6aa4b9bbe2758a10cd4863b704b37093R6-R19) [[2]](diffhunk://#diff-86963609bec6fda3d34233676d5ae33f6aa4b9bbe2758a10cd4863b704b37093L60-R56)
* Modified `MainContent.tsx` to use `GitHubRepository[]` instead of `any` for the `starredRepos` prop, ensuring type safety across the component.
* Refactored `RepoCard.tsx` to replace the inline repository type definition with the `GitHubRepository` interface, simplifying the code and ensuring consistency.
* Updated `RepoList.tsx` to use `GitHubRepository[]` for the `repos` prop, removing redundant inline type definitions.