### PR TITLE
Update default description in RepoCard component

### DIFF
--- a/src/components/RepoCard.tsx
+++ b/src/components/RepoCard.tsx
@@ -74,7 +74,7 @@ export const RepoCard: React.FC<RepoCardType> = ({repo}) => {
               </div>
             </div>
           </div>
-          <div className="card-description">{description || 'No description available'}</div>
+          <div className="card-description">{description || 'Visit repository for details'}</div>
         </div>
       ) : (
         <div className="content content-skeleton">


### PR DESCRIPTION
This pull request makes a small update to the `RepoCard` component to improve the user experience when a repository lacks a description. Now, instead of displaying "No description available," it will show "Visit repository for details."