### PR TITLE
Add welcome screen with sample repositories

### DIFF
--- a/src/components/NoContent.tsx
+++ b/src/components/NoContent.tsx
@@ -1,5 +1,75 @@
 import React from 'react'
+import { RepoCard } from './RepoCard'
+import { GitHubRepository } from '../types/github'
+import '../css/NoContent.css'
+
+const sampleRepos: GitHubRepository[] = [
+  {
+    id: -1,
+    name: 'react',
+    html_url: 'https://github.com/facebook/react',
+    description: 'The library for web and native user interfaces.',
+    owner: { login: 'facebook', avatar_url: '' },
+    language: 'JavaScript',
+    stargazers_count: 234000,
+    created_at: '', updated_at: '',
+    forks_count: 0, open_issues_count: 0,
+    topics: [], archived: false, disabled: false, private: false,
+  },
+  {
+    id: -2,
+    name: 'linux',
+    html_url: 'https://github.com/torvalds/linux',
+    description: 'Linux kernel source tree',
+    owner: { login: 'torvalds', avatar_url: '' },
+    language: 'C',
+    stargazers_count: 217000,
+    created_at: '', updated_at: '',
+    forks_count: 0, open_issues_count: 0,
+    topics: [], archived: false, disabled: false, private: false,
+  },
+  {
+    id: -3,
+    name: 'vscode',
+    html_url: 'https://github.com/microsoft/vscode',
+    description: 'Visual Studio Code',
+    owner: { login: 'microsoft', avatar_url: '' },
+    language: 'TypeScript',
+    stargazers_count: 170000,
+    created_at: '', updated_at: '',
+    forks_count: 0, open_issues_count: 0,
+    topics: [], archived: false, disabled: false, private: false,
+  },
+  {
+    id: -4,
+    name: 'tensorflow',
+    html_url: 'https://github.com/tensorflow/tensorflow',
+    description: 'An Open Source Machine Learning Framework for Everyone',
+    owner: { login: 'tensorflow', avatar_url: '' },
+    language: 'C++',
+    stargazers_count: 188000,
+    created_at: '', updated_at: '',
+    forks_count: 0, open_issues_count: 0,
+    topics: [], archived: false, disabled: false, private: false,
+  },
+]
 
 export const NoContent: React.FC = () => {
-  return <div></div>
+  return (
+    <div className="welcome">
+      <div className="welcome-hero">
+        <span className="welcome-icon" aria-hidden="true">&#9733;</span>
+        <h2 className="welcome-title">Discover what developers are starring on GitHub</h2>
+        <p className="welcome-subtitle">Enter a GitHub username above to explore their starred repositories</p>
+      </div>
+      <div className="welcome-sample">
+        <p className="welcome-sample-label">Popular on GitHub</p>
+        <div className="repo-container repo-cards">
+          {sampleRepos.map((repo) => (
+            <RepoCard key={repo.id} repo={repo} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/css/NoContent.css
+++ b/src/css/NoContent.css
@@ -1,0 +1,43 @@
+.welcome {
+  padding: 2rem 1rem;
+}
+
+.welcome-hero {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.welcome-icon {
+  display: block;
+  font-size: 3rem;
+  color: #f0c040;
+  margin-bottom: 0.75rem;
+}
+
+.welcome-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #24292f;
+  margin: 0 0 0.5rem;
+}
+
+.welcome-subtitle {
+  font-size: 0.95rem;
+  color: #57606a;
+  margin: 0;
+}
+
+.welcome-sample {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.welcome-sample-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #57606a;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 1rem 0.25rem;
+}
+


### PR DESCRIPTION
This pull request enhances the user experience for the empty state by adding a welcoming message and showcasing popular GitHub repositories when there is no content to display. It introduces a new styled layout and sample repository cards to guide users on how to use the app.

User Interface Improvements:

* Updated the `NoContent` component to display a welcome message, instructions, and a list of sample popular repositories using the `RepoCard` component. This helps users understand the purpose of the app and provides visual examples of popular GitHub projects.
* Added a new CSS file, `NoContent.css`, with styles for the welcome layout, hero section, and sample repository cards to ensure a visually appealing and user-friendly presentation.