### PR TITLE
Remove unused anchor styles from RepoCard.css and add them to Top.css for consistency

### DIFF
--- a/src/css/RepoCard.css
+++ b/src/css/RepoCard.css
@@ -1,30 +1,3 @@
-a {
-  color: #0969da;
-  text-decoration: none;
-  transition: all 0.2s ease;
-}
-
-a:hover {
-  color: #0550ae;
-  text-decoration: underline;
-}
-
-a:focus {
-  outline: 3px solid #2185d0;
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-a:focus:not(:focus-visible) {
-  outline: none;
-}
-
-a:focus-visible {
-  outline: 3px solid #2185d0;
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
 .card {
   background: #fff;
   border: 1px solid #d0d7de;

--- a/src/css/Top.css
+++ b/src/css/Top.css
@@ -4,6 +4,33 @@
   box-sizing: border-box;
 }
 
+a {
+  color: #0969da;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+a:hover {
+  color: #0550ae;
+  text-decoration: underline;
+}
+
+a:focus {
+  outline: 3px solid #2185d0;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+a:focus:not(:focus-visible) {
+  outline: none;
+}
+
+a:focus-visible {
+  outline: 3px solid #2185d0;
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
 .top {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
This pull request moves the global anchor (`a`) tag styles from `RepoCard.css` to `Top.css` for better organization and maintainability. There are no functional changes to the styles themselves; only the location of the CSS rules has changed.

CSS organization:

* Removed global anchor (`a`) tag styles from `src/css/RepoCard.css` to avoid duplication and improve file structure.
* Added the same anchor (`a`) tag styles to `src/css/Top.css` so that all global link styles are defined in a single place.